### PR TITLE
Fix escape sequences for custom bash prompt

### DIFF
--- a/usr/share/archboot/base/etc/profile.d/custom-bash-options.sh
+++ b/usr/share/archboot/base/etc/profile.d/custom-bash-options.sh
@@ -6,10 +6,10 @@
 [[ $- == *i* ]] || return
 if [[ "${UID}" == 0 ]]; then
     # red for root user, host green, print full working dir
-    PS1='[\[\e[1;31m\]\u\[\e[m\]@\[\e[1;32m\]\h\[\e[m\] \e[1m\w\e[m]\$ '
+    PS1='[\[\e[1;31m\]\u\[\e[m\]@\[\e[1;32m\]\h\[\e[m\] \[\e[1m\]\w\[\e[m\]] \$ '
 else
     # blue for normal user,host green, print full working dir
-    PS1='[\[\e[1;34m\]\u\[\e[m\]@\[\e[1;32m\]\h\[\e[m\] \e[1m\w\e[m]\$ '
+    PS1='[\[\e[1;34m\]\u\[\e[m\]@\[\e[1;32m\]\h\[\e[m\] \[\e[1m\]\w\[\e[m\]] \$ '
 fi
 # color man pages
 export GROFF_NO_SGR=1


### PR DESCRIPTION
The cursor was off by 7 characters when trying to edit a history line that wrapped in the console. This fixes it so bash properly doesn't count the non-printing characters.